### PR TITLE
Fix query with dictionary parameters

### DIFF
--- a/apswutils/db.py
+++ b/apswutils/db.py
@@ -418,7 +418,7 @@ class Database:
         :param params: Parameters to use in that query - an iterable for ``where id = ?``
           parameters, or a dictionary for ``where id = :id``
         """
-        cursor = self.execute(sql, tuple(params or tuple()))
+        cursor = self.execute(sql, params or tuple())
         cursor.row_trace = cursor_row2dict
         yield from cursor
 


### PR DESCRIPTION
This fixes bug where in `db.q(qry + ' where key = :key', {'key': 'value'})` only 'key' is left, leading to the incorrect result